### PR TITLE
Make basic auth optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You can also read the official Cloud Foundry guide which has detailed informatio
 
 You can change the path for serving metrics (by default `/metrics`) by setting the `PROMETHEUS_METRICS_PATH` [environment variable][].
 
+If you are running `blue-green` deployments through a cf plugin like [autopilot][] you should disable basic auth on the `\metrics` endpoint and use [IP whitelisting][] by setting the `METRICS_BASIC_AUTH` [environment variable][] to `false`. This will minimise gaps in metrics during deployment.
+
 ## How to setup extended metrics
 
 While common metrics are recorded by default, you can also:
@@ -111,3 +113,4 @@ This project is licensed under the [MIT License][].
 [environment variable]: https://docs.cloud.service.gov.uk/#environment-variables
 [Prometheus documentation]: https://prometheus.io/docs/concepts/metric_types/
 [MIT License]: https://github.com/alphagov/gds_metrics_python/blob/master/LICENSE
+[IP whitelisting]: https://reliability-engineering.cloudapps.digital/manuals/monitor-paas-app-with-prometheus.html#ip-whitelist-your-app-metrics-endpoint

--- a/gds_metrics/__init__.py
+++ b/gds_metrics/__init__.py
@@ -28,7 +28,10 @@ class GDSMetrics(object):
 
     def __init__(self):
         self.metrics_path = os.environ.get('PROMETHEUS_METRICS_PATH', '/metrics')
-        self.auth_token = json.loads(os.environ.get("VCAP_APPLICATION", "{}")).get("application_id")
+        if os.environ.get("METRICS_BASIC_AUTH", "true") == "true":
+            self.auth_token = json.loads(os.environ.get("VCAP_APPLICATION", "{}")).get("application_id")
+        else:
+            self.auth_token = False
 
         self.registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(self.registry)

--- a/gds_metrics/version.py
+++ b/gds_metrics/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.1.1'  # pragma: no cover
+__version__ = '0.2.0'  # pragma: no cover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,23 @@ def client(app):
 
 
 @pytest.fixture(scope='function')
+def client_without_basic_auth(app, mocker):
+    with app.test_request_context(), app.test_client() as client:
+        mocker.patch.dict(
+            os.environ,
+            {
+                'VCAP_APPLICATION': '{"application_id": "' + FAKE_APP_ID + '"}',
+                'METRICS_BASIC_AUTH': 'false'
+            }
+        )
+
+        metrics = GDSMetrics()
+        metrics.init_app(app)
+
+        yield client
+
+
+@pytest.fixture(scope='function')
 def client_without_env_app_id(app, mocker):
     with app.test_request_context(), app.test_client() as client:
         mocker.patch.dict(os.environ, {'VCAP_APPLICATION': '{}'})

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -17,6 +17,11 @@ def test_auth_header_returns_expected_response(client, auth_header, expected_sta
     assert response.status_code == expected_status
 
 
+def test_no_basic_auth_env_flag_returns_200(client_without_basic_auth):
+    response = client_without_basic_auth.get('/metrics')
+    assert response.status_code == 200
+
+
 def test_metrics_path_without_app_id_env_does_not_need_auth(client_without_env_app_id):
     response = client_without_env_app_id.get('/metrics')
     assert response.status_code == 200


### PR DESCRIPTION
## What

In order to minimise gaps between deployments rather than using basic auth that relies on the `guid` of the app, it's better to IP whitelist the `\metrics` endpoint so that the prometheus stack will have access.

## Reference 

https://trello.com/c/1xJDLdmK/418-blue-green-deploys-for-registers-trigger-our-dashboard-to-display-0-healthy-instances