### PR TITLE
Unpin prometheus client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.2
+* You can now use versions of prometheus-client newer than v0.2.0 (thanks @leohemsted)
+
 ## 0.2.1
 * Fixes a bug with uncaught AttributeErrors if the `before_request` function did not run before `teardown_request`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use GDS metrics you must:
 
 1. Add the [latest version of the package][] to your `requirements.txt`, for example:
 
-    `gds-metrics==0.1.1`
+    `gds-metrics==0.2.2`
 
 2. Run the following command to install the package:
 

--- a/gds_metrics/version.py
+++ b/gds_metrics/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.1'  # pragma: no cover
+__version__ = '0.2.2'  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "prometheus_client==0.2.0",
+        "prometheus_client>=0.2.0",
         "Flask>=0.10",
         "blinker>=1.4",
     ],


### PR DESCRIPTION
unpinning the prometheus-client enables people to use versions of prometheus-client that better fit their own project.

higher versions of prometheus_client bring significant performance increases. They also (between 0.3 and 0.4) break local db file compatibility with older versions of the local client, so if you upgrade in place you'll lose data