### PR TITLE
Pin prometheus-client version to older than 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3
+
+### Bug fixes
+
+* You can no longer use versions of prometheus-client newer than v0.4.0, as they do not currently work with this package
+
 ## 0.2.2
 * You can now use versions of prometheus-client newer than v0.2.0 (thanks @leohemsted)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use GDS metrics you must:
 
 1. Add the [latest version of the package][] to your `requirements.txt`, for example:
 
-    `gds-metrics==0.2.2`
+    `gds-metrics==0.2.3`
 
 2. Run the following command to install the package:
 

--- a/gds_metrics/version.py
+++ b/gds_metrics/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.2'  # pragma: no cover
+__version__ = '0.2.3'  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "prometheus_client>=0.2.0",
+        "prometheus_client>=0.2.0,<0.5.0",
         "Flask>=0.10",
         "blinker>=1.4",
     ],


### PR DESCRIPTION
Something changed between 0.4.x and 0.5.0 that breaks our tests. We should fix that. In the meantime, lets make sure that people aren't using incompatible versions.