### PR TITLE
Fix tests to be compatible with python client > 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 env:
 - PROMETHEUS_CLIENT_VERSION="0.2.*"
 - PROMETHEUS_CLIENT_VERSION="0.4.*"
+- PROMETHEUS_CLIENT_VERSION="0.8.*"
 cache: pip
 install:
 - pip install -r requirements-test.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.4
+
+### Bug fixes
+
+* You can now use versions of prometheus-client newer than v0.4.0.
+
 ## 0.2.3
 
 ### Bug fixes

--- a/gds_metrics/version.py
+++ b/gds_metrics/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.3'  # pragma: no cover
+__version__ = '0.2.4'  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "prometheus_client>=0.2.0",
+        "prometheus_client>=0.2.0,<1.0.0",
         "Flask>=0.10",
         "blinker>=1.4",
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "prometheus_client>=0.2.0,<0.5.0",
+        "prometheus_client>=0.2.0",
         "Flask>=0.10",
         "blinker>=1.4",
     ],


### PR DESCRIPTION
`_wrappedClass` had been dropped in version 0.5.0 so our tests would
fail when run with a more up to date version of the prometheus python
client.

I've changed the tests to now work with both version 0.2.0 and version
0.8.0 and run py.test manually to confirm this.