### PR TITLE
Add prometheus-client to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ python:
 - "3.6"
 - "3.7"
 - "3.8"
+env:
+- PROMETHEUS_CLIENT_VERSION="0.2.*"
+- PROMETHEUS_CLIENT_VERSION="0.4.*"
 cache: pip
 install:
 - pip install -r requirements-test.txt
+- pip install prometheus-client==$PROMETHEUS_CLIENT_VERSION
 - pip install coveralls
 script:
 - flake8


### PR DESCRIPTION
We want to test this package with different versions of prometheus-client. This commit adds the prometheus client version to the Travis CI build matrix[[1]], so Travis will run the tests using each different version specified.

[1]: https://docs.travis-ci.com/user/build-matrix/