### PR TITLE
Flexible authentication

### DIFF
--- a/gds_metrics/__init__.py
+++ b/gds_metrics/__init__.py
@@ -28,13 +28,9 @@ class GDSMetrics(object):
 
     def __init__(self):
         self.metrics_path = os.environ.get('PROMETHEUS_METRICS_PATH', '/metrics')
-        if os.environ.get("METRICS_BASIC_AUTH", "true") == "true":
-            if os.environ.get("METRICS_BASIC_AUTH_TOKEN"):
-                self.auth_token = os.environ["METRICS_BASIC_AUTH_TOKEN"]
-            else:
-                self.auth_token = json.loads(os.environ.get("VCAP_APPLICATION", "{}")).get("application_id")
-        else:
-            self.auth_token = False
+        self.auth_token = os.environ.get("METRICS_BASIC_AUTH_TOKEN")
+        self.application_id = json.loads(os.environ.get("VCAP_APPLICATION", "{}")).get("application_id")
+        self.authenticate_requests = os.environ.get("METRICS_BASIC_AUTH", "true") == "true"
 
         self.registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(self.registry)

--- a/gds_metrics/__init__.py
+++ b/gds_metrics/__init__.py
@@ -42,13 +42,35 @@ class GDSMetrics(object):
         request_finished.connect(self.teardown_request, sender=app)
         got_request_exception.connect(self.handle_exception, sender=app)
 
-    def metrics_endpoint(self):
+    def _authenticate_request(self, auth_header):
+        # if no authentication is required, all requests are authenticated
+        if not self.authenticate_requests:
+            return
+
+        # This maintains the existing functionality where if this is deployed
+        # on a non-PaaS environment the request should be allowed, even though
+        # the METRICS_BASIC_AUTH defaults to true
+        if not self.application_id:
+            return
+
+        # if authentication is requred but auth_header is missing we reject it
+        if not auth_header:
+            abort(401)
+
         if self.auth_token:
-            auth_header = request.headers.get('Authorization', '')
-            if not auth_header:
-                abort(401)
-            elif not hmac.compare_digest(auth_header, 'Bearer {}'.format(self.auth_token)):
-                abort(403)
+            match = hmac.compare_digest(auth_header, 'Bearer {}'.format(self.auth_token))
+            if match:
+                return
+
+        match = hmac.compare_digest(auth_header, 'Bearer {}'.format(self.application_id))
+        if match:
+            return
+
+        abort(403)
+
+    def metrics_endpoint(self):
+        auth_header = request.headers.get('Authorization', '')
+        self._authenticate_request(auth_header)
 
         response = Response(
             prometheus_client.generate_latest(self.registry),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,13 +1,13 @@
 import pytest
 from tests.conftest import FAKE_APP_ID, FAKE_BASIC_AUTH_TOKEN, SLOW_REQUEST_DURATION
 
-VALID_AUTH_HEADER = 'Authorization', 'Bearer {}'.format(FAKE_APP_ID)
+VALID_AUTH_HEADER_APP_ID = 'Authorization', 'Bearer {}'.format(FAKE_APP_ID)
 VALID_AUTH_HEADER_TOKEN = 'Authorization', 'Bearer {}'.format(FAKE_BASIC_AUTH_TOKEN)
 
 
 @pytest.mark.parametrize('auth_header,expected_status', [
     (None, 401),
-    ([VALID_AUTH_HEADER], 200),
+    ([VALID_AUTH_HEADER_APP_ID], 200),
     ([('Authorization', 'Bearer invalid-token')], 403),
 ])
 def test_auth_header_returns_expected_response(client, auth_header, expected_status, mocker):
@@ -21,10 +21,10 @@ def test_auth_header_returns_expected_response(client, auth_header, expected_sta
 @pytest.mark.parametrize('auth_header,expected_status', [
     (None, 401),
     ([VALID_AUTH_HEADER_TOKEN], 200),
-    ([VALID_AUTH_HEADER], 403),
+    ([VALID_AUTH_HEADER_APP_ID], 200),
     ([('Authorization', 'Bearer invalid-token')], 403),
 ])
-def test_auth_token_takes_precedence_over_application_id(client_with_auth_token, auth_header, expected_status):
+def test_auth_token_works_alongside_application_id(client_with_auth_token, auth_header, expected_status):
     response = client_with_auth_token.get('/metrics', headers=auth_header)
     assert response.status_code == expected_status
 
@@ -47,7 +47,7 @@ def test_app_path_does_not_need_auth(client):
 def test_compresses_response_with_gzip_header(client):
     response = client.get(
         '/metrics',
-        headers=[('Accept-Encoding', 'gzip'), (VALID_AUTH_HEADER)]
+        headers=[('Accept-Encoding', 'gzip'), (VALID_AUTH_HEADER_APP_ID)]
     )
     assert response.headers['Content-Encoding'] == 'gzip'
 
@@ -55,7 +55,7 @@ def test_compresses_response_with_gzip_header(client):
 def test_does_not_compress_response_without_gzip_header(client):
     response = client.get(
         '/metrics',
-        headers=[VALID_AUTH_HEADER]
+        headers=[VALID_AUTH_HEADER_APP_ID]
     )
     assert response.headers.get('Content-Encoding') is None
 
@@ -63,7 +63,7 @@ def test_does_not_compress_response_without_gzip_header(client):
 def test_gzip_request_header_does_not_affect_other_paths(app, client):
     response = client.get(
         '/',
-        headers=[('Accept-Encoding', 'gzip'), (VALID_AUTH_HEADER)]
+        headers=[('Accept-Encoding', 'gzip'), (VALID_AUTH_HEADER_APP_ID)]
     )
     assert response.headers.get('Content-Encoding') is None
 
@@ -72,7 +72,7 @@ def test_calls_histogram_observe(client, mocker):
     histogram_labels = mocker.patch('gds_metrics.HTTP_SERVER_REQUEST_DURATION_SECONDS.labels')
     client.get(
         '/slow_request',
-        headers=[(VALID_AUTH_HEADER)]
+        headers=[(VALID_AUTH_HEADER_APP_ID)]
     )
     assert histogram_labels.called
     observe_mock = histogram_labels.return_value.observe
@@ -87,7 +87,7 @@ def test_requests_increases_request_counter(client, mocker):
         'gds_metrics.HTTP_SERVER_REQUESTS_TOTAL.labels')
     client.get(
         '/',
-        headers=[(VALID_AUTH_HEADER)]
+        headers=[(VALID_AUTH_HEADER_APP_ID)]
     )
     assert counter_labels.called
     assert counter_labels.return_value.inc.called
@@ -99,7 +99,7 @@ def test_exception_increases_exception_counter(client, mocker):
 
     response = client.get(
         '/exception',
-        headers=[(VALID_AUTH_HEADER)]
+        headers=[(VALID_AUTH_HEADER_APP_ID)]
     )
     assert response.status_code == 500
     assert counter_labels.called


### PR DESCRIPTION
This builds on top of my [previous change](https://github.com/alphagov/gds_metrics_python/commit/4caf40d92a4f4e6f5ebf875fd82f67e9a4e3275c), to allow both prometheus instances (the shared one, and our own) to use scrape the `/metrics` endpoint of our apps.

Better reviewed commit-by-commit.